### PR TITLE
CurrentIndexName is null when index already exists

### DIFF
--- a/src/Bielu.Examine.ElasticSearch/Services/ElasticsearchService.cs
+++ b/src/Bielu.Examine.ElasticSearch/Services/ElasticsearchService.cs
@@ -25,6 +25,7 @@ public class ElasticsearchService(IElasticSearchClientFactory factory, IIndexSta
             if (indexesMappedToAlias.Count > 0)
             {
                 state.Exist = true;
+                state.CurrentIndexName ??= indexesMappedToAlias.Keys.First().ToString();
 
                 return state.Exist;
             }


### PR DESCRIPTION
When Umbraco is started and an index already exists, the CurrentIndexName remains null . As a result, the GetDocumentCount, among other things, does not work properly.

I admit that it is not very nice that the CurrentIndexName is set in the IndexExists method in this change, but I couldn't actually find a better place for it.