### PR TITLE
Remove "Id" field to prevent duplicates with "id" field

### DIFF
--- a/src/Bielu.Examine.ElasticSearch/Services/ElasticsearchService.cs
+++ b/src/Bielu.Examine.ElasticSearch/Services/ElasticsearchService.cs
@@ -1,4 +1,4 @@
-﻿using Bielu.Examine.Core.Extensions;
+using Bielu.Examine.Core.Extensions;
 using Bielu.Examine.Core.Models;
 using Bielu.Examine.Core.Queries;
 using Bielu.Examine.Core.Regex;
@@ -304,7 +304,7 @@ public class ElasticsearchService(IElasticSearchClientFactory factory, IIndexSta
                     //this is just a dictionary
                     var ad = new BieluExamineDocument
                     {
-                        ["Id"] = d.Id,
+                        //["Id"] = d.Id,
                         [ExamineFieldNames.ItemIdFieldName.FormatFieldName()] = d.Id,
                         [ExamineFieldNames.ItemTypeFieldName.FormatFieldName()] = d.ItemType,
                         [ExamineFieldNames.CategoryFieldName.FormatFieldName()] = d.Category
@@ -318,7 +318,7 @@ public class ElasticsearchService(IElasticSearchClientFactory factory, IIndexSta
 
                     var docArgs = new Events.DocumentWritingEventArgs(d, ad);
                     // OnDocumentWriting(docArgs);
-                    descriptor = descriptor.Index<BieluExamineDocument>(ad, indexTarget, indexingNodeDataArgs => indexingNodeDataArgs.Index(indexTarget).Id(ad["Id"].ToString()));
+                    descriptor = descriptor.Index<BieluExamineDocument>(ad, indexTarget, indexingNodeDataArgs => indexingNodeDataArgs.Index(indexTarget).Id(ad["id"].ToString()));
                 }
             }
             catch (Exception e)

--- a/src/Bielu.Examine.ElasticSearch/Services/PropertyMappingService.cs
+++ b/src/Bielu.Examine.ElasticSearch/Services/PropertyMappingService.cs
@@ -1,4 +1,4 @@
-﻿using Bielu.Examine.Core.Configuration;
+using Bielu.Examine.Core.Configuration;
 using Bielu.Examine.Core.Extensions;
 using Bielu.Examine.Elasticsearch.Model;
 using Elastic.Clients.Elasticsearch.Mapping;
@@ -60,7 +60,7 @@ public class PropertyMappingService(BieluExamineConfiguration configuration) : I
         ReadOnlyFieldDefinitionCollection fieldDefinitionCollection, string analyzer)
     {
 
-        descriptor.Keyword( "Id");
+        //descriptor.Keyword( "Id");
         descriptor.Keyword( ExamineFieldNames.ItemIdFieldName.FormatFieldName());
         descriptor.Keyword( ExamineFieldNames.ItemTypeFieldName.FormatFieldName());
         descriptor.Keyword( ExamineFieldNames.CategoryFieldName.FormatFieldName());


### PR DESCRIPTION
There were multiple id-fields. By removing the "**Id**"-field, the standard "**id**"-field is used.