### PR TITLE
Set MemberIndex to BieluExamineUmbracoMemberIndex

### DIFF
--- a/src/Bielu.Examine.Umbraco/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Bielu.Examine.Umbraco/Extensions/ServiceCollectionExtensions.cs
@@ -31,7 +31,7 @@ public static class UmbracoBuilderExtensions
             .InternalIndexName);
         builder.Services.AddBieluExamineIndex<BieluExamineUmbracoContentIndex>(global::Umbraco.Cms.Core.Constants.UmbracoIndexes
             .ExternalIndexName);
-        builder.Services.AddBieluExamineIndex<BieluExamineUmbracoContentIndex>(global::Umbraco.Cms.Core.Constants.UmbracoIndexes
+        builder.Services.AddBieluExamineIndex<BieluExamineUmbracoMemberIndex>(global::Umbraco.Cms.Core.Constants.UmbracoIndexes
             .MembersIndexName);
         builder.Services.AddBieluExamineIndex<BieluExamineUmbracoDeliveryApiContentIndex>(global::Umbraco.Cms.Core.Constants.UmbracoIndexes
             .DeliveryApiContentIndexName);


### PR DESCRIPTION
When changing the MemberIndex from BieluExamineUmbracoContentIndex to BieluExamineUmbracoMemberIndex the memberindex is populating again.