### PR TITLE
Getting the right metadata in the dashboard after indexing.

### DIFF
--- a/src/Bielu.Examine.Core/Indexers/ElasticSearchBaseIndex.cs
+++ b/src/Bielu.Examine.Core/Indexers/ElasticSearchBaseIndex.cs
@@ -19,8 +19,8 @@ public class ElasticSearchBaseIndex(
     IOptionsMonitor<LuceneDirectoryIndexOptions> indexOptions)
     : BaseIndexProvider(loggerFactory, name, indexOptions), IBieluExamineIndex, IDisposable, IObserver<TransformingObservable>
 {
-    private bool _exists;
-    private ExamineIndexState IndexState => indexStateService.GetIndexState(name);
+    private ExamineIndexState IndexState => indexStateService.GetIndexState(name, elasticSearchService);
+
     private static readonly object _existsLocker = new object();
 
     private IDisposable Unsubscriber;
@@ -69,20 +69,11 @@ public class ElasticSearchBaseIndex(
 
     public override void CreateIndex()
     {
-        _exists = false;
         elasticSearchService.EnsuredIndexExists(name, Analyzer, FieldDefinitions, true);
     }
 
-    public override bool IndexExists()
-    {
-        if (!_exists)
-        {
-            _exists = elasticSearchService.IndexExists(IndexName);
-        }
-
-        return _exists;
-    }
-
+    public override bool IndexExists() => IndexState.Exist;
+    
     public override ISearcher Searcher => CreateSearcher();
 
     public void SwapIndex()

--- a/src/Bielu.Examine.Core/Services/IIndexStateService.cs
+++ b/src/Bielu.Examine.Core/Services/IIndexStateService.cs
@@ -1,8 +1,8 @@
-﻿using Bielu.Examine.Core.Models;
+using Bielu.Examine.Core.Models;
 
 namespace Bielu.Examine.Core.Services;
 
 public interface IIndexStateService
 {
-    public ExamineIndexState GetIndexState(string indexName);
+    public ExamineIndexState GetIndexState(string indexName, ISearchService searchService);
 }

--- a/src/Bielu.Examine.ElasticSearch/Providers/ElasticsearchExamineSearcher.cs
+++ b/src/Bielu.Examine.ElasticSearch/Providers/ElasticsearchExamineSearcher.cs
@@ -1,4 +1,4 @@
-﻿using Bielu.Examine.Core.Models;
+using Bielu.Examine.Core.Models;
 using Bielu.Examine.Core.Queries;
 using Bielu.Examine.Core.Services;
 using Bielu.Examine.Elasticsearch.Configuration;
@@ -28,7 +28,7 @@ public class ElasticsearchExamineSearcher(string name, string? indexAlias, ILogg
     private readonly List<SortField> _sortFields = new List<SortField>();
     private string?[] _allFields;
     private IEnumerable<ExamineProperty>? _fieldsMapping;
-    private bool? _exists;
+    private bool _exists;
 
 
     private static readonly string[]? _emptyFields = Array.Empty<string>();
@@ -36,12 +36,11 @@ public class ElasticsearchExamineSearcher(string name, string? indexAlias, ILogg
     {
         get
         {
-            if(_exists.HasValue)
+            if (!_exists)
             {
-                return (bool)_exists;
+                _exists = elasticsearchService.IndexExists(name);
             }
-            _exists = elasticsearchService.IndexExists(name);
-            return (bool)_exists;
+            return _exists;
         }
     }
 

--- a/src/Bielu.Examine.ElasticSearch/Providers/ElasticsearchExamineSearcher.cs
+++ b/src/Bielu.Examine.ElasticSearch/Providers/ElasticsearchExamineSearcher.cs
@@ -22,27 +22,16 @@ using Query = Elastic.Clients.Elasticsearch.QueryDsl.Query;
 
 namespace Bielu.Examine.Elasticsearch.Providers;
 
-public class ElasticsearchExamineSearcher(string name, string? indexAlias, ILoggerFactory loggerFactory, ISearchService elasticsearchService) : BaseSearchProvider(name),IBieluExamineSearcher, IDisposable
+public class ElasticsearchExamineSearcher(string name, string? indexAlias, ILoggerFactory loggerFactory, ISearchService elasticsearchService, IIndexStateService indexStateService) : BaseSearchProvider(name),IBieluExamineSearcher, IDisposable
 {
     public string? IndexAlias => indexAlias;
     private readonly List<SortField> _sortFields = new List<SortField>();
     private string?[] _allFields;
     private IEnumerable<ExamineProperty>? _fieldsMapping;
-    private bool _exists;
-
+    private ExamineIndexState IndexState => indexStateService.GetIndexState(name, elasticsearchService);
 
     private static readonly string[]? _emptyFields = Array.Empty<string>();
-    public bool IndexExists
-    {
-        get
-        {
-            if (!_exists)
-            {
-                _exists = elasticsearchService.IndexExists(name);
-            }
-            return _exists;
-        }
-    }
+    public bool IndexExists => IndexState.Exist;
 
 
     public string[] AllFields

--- a/src/Bielu.Examine.ElasticSearch/Services/ElasticBieluSearchFactory.cs
+++ b/src/Bielu.Examine.ElasticSearch/Services/ElasticBieluSearchFactory.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 using Bielu.Examine.Core.Services;
 using Bielu.Examine.Elasticsearch.Providers;
 using Microsoft.Extensions.Logging;
@@ -15,8 +15,8 @@ public class ElasticBieluSearchManager(IIndexStateService stateService, ILoggerF
         {
             return searcher;
         }
-        var state = stateService.GetIndexState(indexName);
-        searcher = new ElasticsearchExamineSearcher(indexName, state.IndexAlias, loggerFactory, service);
+        var state = stateService.GetIndexState(indexName, service);
+        searcher = new ElasticsearchExamineSearcher(indexName, state.IndexAlias, loggerFactory, service, stateService);
         _searchers.TryAdd(indexName, searcher);
         return searcher;
     }

--- a/src/Bielu.Examine.ElasticSearch/Services/ElasticSearchClientFactory.cs
+++ b/src/Bielu.Examine.ElasticSearch/Services/ElasticSearchClientFactory.cs
@@ -1,4 +1,4 @@
-﻿using Bielu.Examine.Elasticsearch.Configuration;
+using Bielu.Examine.Elasticsearch.Configuration;
 using Bielu.Examine.Elasticsearch.Constants;
 using Elastic.Clients.Elasticsearch;
 using Elastic.Transport;
@@ -8,7 +8,7 @@ namespace Bielu.Examine.Elasticsearch.Services;
 
 public class ElasticSearchClientFactory(IOptionsMonitor<BieluExamineElasticOptions> examineElasticOptions) : IElasticSearchClientFactory
 {
-    Dictionary<string?, ElasticsearchClient> _clients = new Dictionary<string?, ElasticsearchClient>();
+    Dictionary<string, ElasticsearchClient> _clients = new Dictionary<string, ElasticsearchClient>();
 
     public ElasticsearchClient GetOrCreateClient(string? indexName)
     {

--- a/src/Bielu.Examine.ElasticSearch/Services/ElasticsearchService.cs
+++ b/src/Bielu.Examine.ElasticSearch/Services/ElasticsearchService.cs
@@ -33,7 +33,7 @@ public class ElasticsearchService(
 
     public bool IndexExists(string examineIndexName)
     {
-        var state = service.GetIndexState(examineIndexName);
+        var state = service.GetIndexState(examineIndexName, this);
         var client = GetClient(examineIndexName);
         var aliasExists = client.Indices.Exists(state.IndexAlias).Exists;
         if (aliasExists)
@@ -54,7 +54,7 @@ public class ElasticsearchService(
 
     public IEnumerable<string>? GetCurrentIndexNames(string examineIndexName)
     {
-        var state = service.GetIndexState(examineIndexName);
+        var state = service.GetIndexState(examineIndexName, this);
         return GetIndexesAssignedToAlias(GetClient(examineIndexName), state.IndexAlias);
     }
 
@@ -66,7 +66,7 @@ public class ElasticsearchService(
 
     public BieluExamineSearchResults Search(string examineIndexName, QueryOptions? options, Query query)
     {
-        var state = service.GetIndexState(examineIndexName);
+        var state = service.GetIndexState(examineIndexName, this);
         var queryContainer = new QueryStringQuery()
         {
             Query = QueryRegex.PathRegex().Replace(query.ToString(), "$1\\-"), AnalyzeWildcard = true
@@ -100,14 +100,14 @@ public class ElasticsearchService(
         {
             if (overrideExisting)
             {
-                var state = service.GetIndexState(examineIndexName);
+                var state = service.GetIndexState(examineIndexName, this);
                 state.Reindexing = true;
                 CreateIndex(examineIndexName, analyzer, fieldsMapping);
             }
         }
         else
         {
-            var state = service.GetIndexState(examineIndexName);
+            var state = service.GetIndexState(examineIndexName, this);
             state.Reindexing = true;
             CreateIndex(examineIndexName, analyzer, fieldsMapping);
         }
@@ -137,7 +137,7 @@ public class ElasticsearchService(
         Func<PropertiesDescriptor<BieluExamineDocument>, PropertiesDescriptor<BieluExamineDocument>> fieldsMapping)
     {
         var client = GetClient(examineIndexName);
-        var state = service.GetIndexState(examineIndexName);
+        var state = service.GetIndexState(examineIndexName, this);
         if (state.CreatingNewIndex)
         {
             return;
@@ -194,7 +194,7 @@ public class ElasticsearchService(
     public IEnumerable<string>? GetPropertiesNames(string examineIndexName)
     {
         var client = GetClient(examineIndexName);
-        var state = service.GetIndexState(examineIndexName);
+        var state = service.GetIndexState(examineIndexName, this);
 
         var indexesMappedToAlias = GetIndexesAssignedToAlias(client, state.IndexAlias).ToList();
         if (indexesMappedToAlias.Count <= 0)
@@ -210,7 +210,7 @@ public class ElasticsearchService(
     public IEnumerable<ExamineProperty>? GetProperties(string examineIndexName)
     {
         var client = GetClient(examineIndexName);
-        var state = service.GetIndexState(examineIndexName);
+        var state = service.GetIndexState(examineIndexName, this);
 
         var indexesMappedToAlias = GetIndexesAssignedToAlias(client, state.IndexAlias).ToList();
         if (indexesMappedToAlias.Count <= 0)
@@ -243,7 +243,7 @@ public class ElasticsearchService(
     public void SwapTempIndex(string? examineIndexName)
     {
         var client = GetClient(examineIndexName);
-        var state = service.GetIndexState(examineIndexName);
+        var state = service.GetIndexState(examineIndexName, this);
         var oldIndexes = GetIndexesAssignedToAlias(client, state.IndexAlias);
         var bulkAliasResponse = client.Indices.UpdateAliases(x =>
             x.Actions(a => a.Add(add => add.Index(state.CurrentTemporaryIndexName).Alias(state.IndexAlias))));
@@ -268,7 +268,7 @@ public class ElasticsearchService(
     {
         var totalResults = 0L;
         var client = GetClient(examineIndexName);
-        var state = service.GetIndexState(examineIndexName);
+        var state = service.GetIndexState(examineIndexName, this);
         if (!IndexExists(examineIndexName))
         {
             return 0;
@@ -289,7 +289,7 @@ public class ElasticsearchService(
     public long DeleteBatch(string? examineIndexName, IEnumerable<string> itemIds)
     {
         var client = GetClient(examineIndexName);
-        var state = service.GetIndexState(examineIndexName);
+        var state = service.GetIndexState(examineIndexName, this);
         var descriptor = new BulkRequestDescriptor();
         foreach (var id in itemIds)
         {
@@ -303,7 +303,7 @@ public class ElasticsearchService(
     public int GetDocumentCount(string? examineIndexName)
     {
         var client = GetClient(examineIndexName);
-        var state = service.GetIndexState(examineIndexName);
+        var state = service.GetIndexState(examineIndexName, this);
 
         return (int)client.Count(index => index.Index(state.CurrentIndexName)).Count;
     }

--- a/src/Bielu.Examine.ElasticSearch/Services/ElasticsearchService.cs
+++ b/src/Bielu.Examine.ElasticSearch/Services/ElasticsearchService.cs
@@ -9,7 +9,6 @@ using Elastic.Clients.Elasticsearch;
 using Elastic.Clients.Elasticsearch.IndexManagement;
 using Elastic.Clients.Elasticsearch.Mapping;
 using Elastic.Clients.Elasticsearch.QueryDsl;
-using Elastic.Transport.Extensions;
 using Examine;
 using Examine.Lucene.Search;
 using Examine.Search;
@@ -309,9 +308,9 @@ public class ElasticsearchService(
         return (int)client.Count(index => index.Index(state.CurrentIndexName)).Count;
     }
 
-    public bool HealthCheck(string? examineIndexNam)
+    public bool HealthCheck(string? examineIndexName)
     {
-        var client = GetClient(examineIndexNam);
+        var client = GetClient(examineIndexName);
         return client.Cluster.Health().Status == HealthStatus.Green ||
                client.Cluster.Health().Status == HealthStatus.Yellow;
     }
@@ -324,7 +323,7 @@ public class ElasticsearchService(
 
     private static string CreateIndexName(string indexAlias)
     {
-        return $"{indexAlias}_{DateTime.UtcNow:yyyyMMddHHmmss}";
+        return $"{indexAlias}_{DateTime.Now:yyyyMMddHHmmss}";
     }
 
     private BulkRequestDescriptor ToElasticSearchDocs(IEnumerable<ValueSet> docs, string? indexTarget)

--- a/src/Bielu.Examine.ElasticSearch/Services/ElasticsearchService.cs
+++ b/src/Bielu.Examine.ElasticSearch/Services/ElasticsearchService.cs
@@ -349,7 +349,7 @@ public class ElasticsearchService(
                 //this is just a dictionary
                 var ad = new BieluExamineDocument
                 {
-                    //["Id"] = d.Id,
+                    ["id"] = d.Id,
                     [ExamineFieldNames.ItemIdFieldName.FormatFieldName()] = d.Id,
                     [ExamineFieldNames.ItemTypeFieldName.FormatFieldName()] = d.ItemType,
                     [ExamineFieldNames.CategoryFieldName.FormatFieldName()] = d.Category

--- a/src/Bielu.Examine.ElasticSearch/Services/IndexStateService.cs
+++ b/src/Bielu.Examine.ElasticSearch/Services/IndexStateService.cs
@@ -9,7 +9,8 @@ namespace Bielu.Examine.Elasticsearch.Services;
 public class IndexStateService(IOptionsMonitor<BieluExamineElasticOptions> examineElasticOptions) : IIndexStateService
 {
     private Dictionary<string, ExamineIndexState> _indexStates = [];
-    public ExamineIndexState GetIndexState(string indexName)
+
+    public ExamineIndexState GetIndexState(string indexName, ISearchService searchService)
     {
         if (_indexStates.TryGetValue(indexName, out var state))
         {
@@ -30,6 +31,7 @@ public class IndexStateService(IOptionsMonitor<BieluExamineElasticOptions> exami
         state.IndexAlias = $"{prefix}{indexName.ToLowerInvariant()}";
         state.TempIndexAlias = $"{prefix}temp_{indexName.ToLowerInvariant()}";
         _indexStates[indexName] = state;
+        state.Exist = searchService?.IndexExists(indexName) ?? false;
         return state;
     }
 }

--- a/src/Bielu.Examine.Umbraco.Forms/Composer/ElasticSearchExamineUmbracoFormsComposer.cs
+++ b/src/Bielu.Examine.Umbraco.Forms/Composer/ElasticSearchExamineUmbracoFormsComposer.cs
@@ -1,16 +1,18 @@
-﻿using Bielu.Examine.Core.Configuration;
+using Bielu.Examine.Core.Configuration;
 using Bielu.Examine.Core.Services;
 using Bielu.Examine.ElasticSearch.Umbraco.Form.Indexer;
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.DependencyInjection;
 using bielu.Examine.Umbraco.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Bielu.Examine.ElasticSearch.Umbraco.Form.Configuration;
 namespace Bielu.Examine.ElasticSearch.Umbraco.Form.Composer;
 public static class BieluExamineConfiguratorExtensions
 {
 
     public static BieluExamineConfigurator AddFormProvider(this BieluExamineConfigurator builder)
     {
-        builder.ServiceCollection.AddBieluExamineIndex<BieluExamineUmbracoFormsIndex>(global::Umbraco.Forms.Core.Constants.ExamineIndex.RecordIndexName);
+        builder.ServiceCollection.AddBieluExamineIndex<BieluExamineUmbracoFormsIndex>(global::Umbraco.Forms.Core.Constants.ExamineIndex.RecordIndexName).ConfigureOptions<ConfigureUmbracoFormsIndexOptions>();
         return builder;
     }
 }

--- a/src/Bielu.Examine.Umbraco.Forms/Configuration/ConfigureUmbracoFormsIndexOptions.cs
+++ b/src/Bielu.Examine.Umbraco.Forms/Configuration/ConfigureUmbracoFormsIndexOptions.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Examine.Lucene.Analyzers;
+using Examine.Lucene;
+using Examine;
+using Lucene.Net.Analysis;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Infrastructure.Examine;
+using Umbraco.Forms.Examine.Indexes;
+
+namespace Bielu.Examine.ElasticSearch.Umbraco.Form.Configuration;
+public class ConfigureUmbracoFormsIndexOptions :
+    IConfigureNamedOptions<LuceneDirectoryIndexOptions>,
+    IConfigureOptions<LuceneDirectoryIndexOptions>
+{
+    private readonly IUmbracoIndexConfig _umbracoIndexConfig;
+
+    public ConfigureUmbracoFormsIndexOptions(IUmbracoIndexConfig umbracoIndexConfig)
+    {
+        this._umbracoIndexConfig = umbracoIndexConfig;
+    }
+
+    public void Configure(LuceneDirectoryIndexOptions options)
+    {
+        throw new NotSupportedException("This is never called and is just part of the interface");
+    }
+
+    public void Configure(string? name, LuceneDirectoryIndexOptions options)
+    {
+        if (!(name == "UmbracoFormsRecordsIndex"))
+            return;
+        options.Analyzer = (Analyzer)new CultureInvariantWhitespaceAnalyzer();
+        options.Validator = (IValueSetValidator)new RecordValueSetValidator();
+        options.FieldDefinitions = new FieldDefinitionCollection(new FieldDefinition[] { });
+    }
+}

--- a/src/Bielu.Examine.Umbraco.Forms/Indexer/UmbracoFormsElasticIndex.cs
+++ b/src/Bielu.Examine.Umbraco.Forms/Indexer/UmbracoFormsElasticIndex.cs
@@ -1,4 +1,4 @@
-﻿using Bielu.Examine.Core.Services;
+using Bielu.Examine.Core.Services;
 using bielu.Examine.Umbraco.Indexers.Indexers;
 using Examine;
 using Examine.Lucene;
@@ -9,7 +9,7 @@ using Umbraco.Forms.Examine.Indexes;
 
 namespace Bielu.Examine.ElasticSearch.Umbraco.Form.Indexer;
 
-public class BieluExamineUmbracoFormsIndex(string? name, ILoggerFactory loggerFactory, IRuntime runtime,  ILogger<IBieluExamineIndex> logger,ISearchService searchService, IIndexStateService stateService, IBieluSearchManager manager, IOptionsMonitor<LuceneDirectoryIndexOptions> indexOptions) : BieluExamineUmbracoIndex(name, loggerFactory,runtime, logger,searchService,stateService,manager, indexOptions),IUmbracoFormsRecordIndex
+public class BieluExamineUmbracoFormsIndex(string? name, ILoggerFactory loggerFactory, IRuntime runtime, ILogger<IBieluExamineIndex> logger, ISearchService searchService, IIndexStateService stateService, IBieluSearchManager manager, IOptionsMonitor<LuceneDirectoryIndexOptions> indexOptions) : BieluExamineUmbracoIndex(name, loggerFactory, runtime, logger, searchService, stateService, manager, indexOptions), IUmbracoFormsRecordIndex
 {
 
 }

--- a/src/Bielu.Examine.Umbraco/ElasticsearchExamineIndexRebuilder.cs
+++ b/src/Bielu.Examine.Umbraco/ElasticsearchExamineIndexRebuilder.cs
@@ -169,20 +169,14 @@ public class ElasticsearchExamineIndexRebuilder :IIndexRebuilder
                     populator.Populate(index);
                 }
 
-                // Reset the cache for the ExamineManagementController
-                var cacheKey = "temp_indexing_op_" + indexName;
-                _runtimeCache.Insert(cacheKey, () => "tempValue", TimeSpan.FromMinutes(5));
-
                 if (index is IBieluExamineIndex elasticIndex)
                 {
+                    // Reset the ExamineManagementController cache for 1 second  
+                    var cacheKey = "temp_indexing_op_" + indexName;
+                    _runtimeCache.Insert(cacheKey, () => "tempValue", TimeSpan.FromSeconds(1));
+
                     elasticIndex.SwapIndex();
                 }
-
-                // Wait 1 second to get the right DocumentCount back from Elastic
-                Thread.Sleep(1000);
-
-                // Clear the cache for the ExamineManagementController
-                _runtimeCache.ClearByKey(cacheKey);
 
             }
         }

--- a/src/Bielu.Examine.Umbraco/ElasticsearchExamineIndexRebuilder.cs
+++ b/src/Bielu.Examine.Umbraco/ElasticsearchExamineIndexRebuilder.cs
@@ -1,7 +1,8 @@
-﻿using Bielu.Examine.Core.Services;
+using Bielu.Examine.Core.Services;
 using Examine;
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Runtime;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Infrastructure.Examine;
@@ -18,6 +19,7 @@ public class ElasticsearchExamineIndexRebuilder :IIndexRebuilder
     private readonly IEnumerable<IIndexPopulator> _populators;
     private readonly object _rebuildLocker = new();
     private readonly IRuntimeState _runtimeState;
+    private readonly IAppPolicyCache _runtimeCache;
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="ExamineIndexRebuilder" /> class.
@@ -28,7 +30,8 @@ public class ElasticsearchExamineIndexRebuilder :IIndexRebuilder
         ILogger<ExamineIndexRebuilder> logger,
         IExamineManager examineManager,
         IEnumerable<IIndexPopulator> populators,
-        IBackgroundTaskQueue backgroundTaskQueue)
+        IBackgroundTaskQueue backgroundTaskQueue,
+        AppCaches appCaches)
     {
         _mainDom = mainDom;
         _runtimeState = runtimeState;
@@ -36,6 +39,7 @@ public class ElasticsearchExamineIndexRebuilder :IIndexRebuilder
         _examineManager = examineManager;
         _populators = populators;
         _backgroundTaskQueue = backgroundTaskQueue;
+        _runtimeCache = appCaches.RuntimeCache;
     }
 
     public bool CanRebuild(string indexName)
@@ -164,10 +168,22 @@ public class ElasticsearchExamineIndexRebuilder :IIndexRebuilder
 
                     populator.Populate(index);
                 }
+
+                // Reset the cache for the ExamineManagementController
+                var cacheKey = "temp_indexing_op_" + indexName;
+                _runtimeCache.Insert(cacheKey, () => "tempValue", TimeSpan.FromMinutes(5));
+
                 if (index is IBieluExamineIndex elasticIndex)
                 {
                     elasticIndex.SwapIndex();
                 }
+
+                // Wait 1 second to get the right DocumentCount back from Elastic
+                Thread.Sleep(1000);
+
+                // Clear the cache for the ExamineManagementController
+                _runtimeCache.ClearByKey(cacheKey);
+
             }
         }
         finally

--- a/src/Bielu.Examine.Umbraco/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Bielu.Examine.Umbraco/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Bielu.Examine.Core.Configuration;
+using Bielu.Examine.Core.Configuration;
 using Bielu.Examine.Core.Extensions;
 using Bielu.Examine.Core.Services;
 using bielu.Examine.Umbraco.Indexers.Indexers;
@@ -31,11 +31,12 @@ public static class UmbracoBuilderExtensions
             .InternalIndexName);
         builder.Services.AddBieluExamineIndex<BieluExamineUmbracoContentIndex>(global::Umbraco.Cms.Core.Constants.UmbracoIndexes
             .ExternalIndexName);
-        builder.Services.AddBieluExamineIndex<BieluExamineUmbracoContentIndex>(global::Umbraco.Cms.Core.Constants.UmbracoIndexes
+        builder.Services.AddBieluExamineIndex<BieluExamineUmbracoMemberIndex>(global::Umbraco.Cms.Core.Constants.UmbracoIndexes
             .MembersIndexName);
         builder.Services.AddBieluExamineIndex<BieluExamineUmbracoDeliveryApiContentIndex>(global::Umbraco.Cms.Core.Constants.UmbracoIndexes
             .DeliveryApiContentIndexName);
         builder.Services.AddSingleton<IExamineManager, ExamineManager<IBieluExamineIndex>>();
+
         return builder;
     }
     public static IServiceCollection AddBieluExamineIndex<TIndex>(this IServiceCollection serviceCollection, string name) where TIndex : class, IBieluExamineIndex

--- a/src/Bielu.Examine.Umbraco/Indexers/ElasticSearchUmbracoIndex.cs
+++ b/src/Bielu.Examine.Umbraco/Indexers/ElasticSearchUmbracoIndex.cs
@@ -152,7 +152,7 @@ namespace bielu.Examine.Umbraco.Indexers.Indexers
 
         private void AddGeneralMetadata(Dictionary<string, object?> metadata)
         {
-            var state = stateService.GetIndexState(name);
+            var state = stateService.GetIndexState(name, searchService);
             metadata[nameof(DocumentCount)] = DocumentCount;
             metadata[nameof(Name)] = Name;
             metadata[nameof(IndexAlias)] = IndexAlias;

--- a/src/Bielu.Examine.Umbraco/Indexers/ElasticSearchUmbracoIndex.cs
+++ b/src/Bielu.Examine.Umbraco/Indexers/ElasticSearchUmbracoIndex.cs
@@ -1,4 +1,3 @@
-using Bielu.Examine.Core.Extensions;
 using Bielu.Examine.Core.Indexers;
 using Bielu.Examine.Core.Services;
 using Examine;
@@ -14,7 +13,7 @@ using Umbraco.Extensions;
 
 namespace bielu.Examine.Umbraco.Indexers.Indexers
 {
-    public class BieluExamineUmbracoIndex(string? name, ILoggerFactory loggerFactory, IRuntime runtime, ILogger<IBieluExamineIndex> logger,ISearchService searchService, IIndexStateService stateService, IBieluSearchManager manager, IOptionsMonitor<LuceneDirectoryIndexOptions> indexOptions) : ElasticSearchBaseIndex(name, logger, loggerFactory, searchService,stateService,manager,indexOptions), IBieluExamineIndex, IUmbracoIndex, IIndexDiagnostics
+    public class BieluExamineUmbracoIndex(string? name, ILoggerFactory loggerFactory, IRuntime runtime, ILogger<IBieluExamineIndex> logger, ISearchService searchService, IIndexStateService stateService, IBieluSearchManager manager, IOptionsMonitor<LuceneDirectoryIndexOptions> indexOptions) : ElasticSearchBaseIndex(name, logger, loggerFactory, searchService, stateService, manager, indexOptions), IBieluExamineIndex, IUmbracoIndex, IIndexDiagnostics
     {
 
         public const string SpecialFieldPrefix = "__";
@@ -24,7 +23,7 @@ namespace bielu.Examine.Umbraco.Indexers.Indexers
         public const string PublishedFieldName = SpecialFieldPrefix + "Published";
 
         private readonly ISet<string> _idOnlyFieldSet = new HashSet<string> { "id" };
-
+        private readonly LuceneDirectoryIndexOptions _namedOptions = indexOptions.Get(name);
         private readonly IProfilingLogger _logger;
         public bool EnableDefaultEventHandler { get; set; } = true;
         public override string Name => name;
@@ -34,7 +33,7 @@ namespace bielu.Examine.Umbraco.Indexers.Indexers
         public const string RawFieldPrefix = SpecialFieldPrefix + "Raw_";
 
 
-        public long GetDocumentCount() => 0;
+        public long GetDocumentCount() => searchService.GetDocumentCount(name);
         public IEnumerable<string> GetFieldNames() => GetFields();
         public bool SupportProtectedContent => CurrentContentValueSetValidator?.SupportProtectedContent ?? false;
         private readonly bool _configBased;
@@ -46,7 +45,7 @@ namespace bielu.Examine.Umbraco.Indexers.Indexers
         /// </summary>
 
         public bool PublishedValuesOnly => CurrentContentValueSetValidator?.PublishedValuesOnly ?? false;
-        private IContentValueSetValidator? CurrentContentValueSetValidator => indexOptions.CurrentValue.Validator as IContentValueSetValidator;
+        private IContentValueSetValidator? CurrentContentValueSetValidator => _namedOptions.Validator as IContentValueSetValidator;
         /// <summary>
         /// override to check if we can actually initialize.
         /// </summary>
@@ -70,9 +69,9 @@ namespace bielu.Examine.Umbraco.Indexers.Indexers
         /// <param name="e"></param>
         protected override void OnIndexingError(IndexingErrorEventArgs e)
         {
- #pragma warning disable CA1848
+#pragma warning disable CA1848
             logger.LogError(e.Exception, "Error indexing item {NodeId}", e.ItemId);
- #pragma warning restore CA1848
+#pragma warning restore CA1848
             base.OnIndexingError(e);
         }
 

--- a/src/Bielu.Examine.Umbraco/Indexers/UmbracoContentElasticsearchIndex.cs
+++ b/src/Bielu.Examine.Umbraco/Indexers/UmbracoContentElasticsearchIndex.cs
@@ -1,4 +1,4 @@
-﻿using Bielu.Examine.Core.Services;
+using Bielu.Examine.Core.Services;
 using Examine.Lucene;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -7,7 +7,7 @@ using Umbraco.Cms.Infrastructure.Examine;
 
 namespace bielu.Examine.Umbraco.Indexers.Indexers;
 
-public class BieluExamineUmbracoContentIndex(string? name, ILoggerFactory loggerFactory, IRuntime runtime,  ILogger<IBieluExamineIndex> logger,ISearchService searchService, IIndexStateService stateService, IBieluSearchManager manager, IOptionsMonitor<LuceneDirectoryIndexOptions> indexOptions) : BieluExamineUmbracoIndex(name, loggerFactory,runtime, logger,searchService,stateService,manager, indexOptions), IUmbracoContentIndex
+public class BieluExamineUmbracoContentIndex(string? name, ILoggerFactory loggerFactory, IRuntime runtime, ILogger<IBieluExamineIndex> logger, ISearchService searchService, IIndexStateService stateService, IBieluSearchManager manager, IOptionsMonitor<LuceneDirectoryIndexOptions> indexOptions) : BieluExamineUmbracoIndex(name, loggerFactory, runtime, logger, searchService, stateService, manager, indexOptions), IUmbracoContentIndex
 {
 
 }

--- a/src/Bielu.Examine.Umbraco/Indexers/UmbracoDeliveryApiContentElasticSearchIndex.cs
+++ b/src/Bielu.Examine.Umbraco/Indexers/UmbracoDeliveryApiContentElasticSearchIndex.cs
@@ -1,13 +1,12 @@
-﻿using Bielu.Examine.Core.Services;
+using Bielu.Examine.Core.Services;
 using Examine.Lucene;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Services;
-using Umbraco.Cms.Infrastructure.Examine;
 
 namespace bielu.Examine.Umbraco.Indexers.Indexers;
 
-public class BieluExamineUmbracoDeliveryApiContentIndex(string? name, ILoggerFactory loggerFactory, IRuntime runtime,  ILogger<IBieluExamineIndex> logger,ISearchService searchService, IIndexStateService stateService, IBieluSearchManager manager, IOptionsMonitor<LuceneDirectoryIndexOptions> indexOptions) : BieluExamineUmbracoIndex(name, loggerFactory,runtime, logger,searchService,stateService,manager, indexOptions)
+public class BieluExamineUmbracoDeliveryApiContentIndex(string? name, ILoggerFactory loggerFactory, IRuntime runtime, ILogger<IBieluExamineIndex> logger, ISearchService searchService, IIndexStateService stateService, IBieluSearchManager manager, IOptionsMonitor<LuceneDirectoryIndexOptions> indexOptions) : BieluExamineUmbracoIndex(name, loggerFactory, runtime, logger, searchService, stateService, manager, indexOptions)
 {
 
 }

--- a/src/Bielu.Examine.Umbraco/Indexers/UmbracoMemberElasticSearchIndex.cs
+++ b/src/Bielu.Examine.Umbraco/Indexers/UmbracoMemberElasticSearchIndex.cs
@@ -1,4 +1,4 @@
-﻿using Bielu.Examine.Core.Services;
+using Bielu.Examine.Core.Services;
 using Examine.Lucene;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -7,7 +7,7 @@ using Umbraco.Cms.Infrastructure.Examine;
 
 namespace bielu.Examine.Umbraco.Indexers.Indexers;
 
-public class BieluExamineUmbracoMemberIndex(string? name, ILoggerFactory loggerFactory, IRuntime runtime,  ILogger<IBieluExamineIndex> logger,ISearchService searchService, IIndexStateService stateService, IBieluSearchManager manager, IOptionsMonitor<LuceneDirectoryIndexOptions> indexOptions) : BieluExamineUmbracoIndex(name, loggerFactory,runtime, logger,searchService,stateService,manager, indexOptions),IUmbracoMemberIndex
+public class BieluExamineUmbracoMemberIndex(string? name, ILoggerFactory loggerFactory, IRuntime runtime, ILogger<IBieluExamineIndex> logger, ISearchService searchService, IIndexStateService stateService, IBieluSearchManager manager, IOptionsMonitor<LuceneDirectoryIndexOptions> indexOptions) : BieluExamineUmbracoIndex(name, loggerFactory, runtime, logger, searchService, stateService, manager, indexOptions), IUmbracoMemberIndex
 {
 
 }


### PR DESCRIPTION
The metadata was not correctly shown on the Examine Management dashboard.

The main reason for this was to check whether an index already exists or not. Once set this was not updated. As a result, the fields were not returned.
In addition, GetDocumentCount always returned 0.

An other problem was that when an index was rebuilt, Elastic did not immediately return the correct number of documents and returned 0. In my case, by adding a 1 second delay after reindexing, the correct number of documents was obtained. I'm not sure if this is sufficient for an index with very many documents.

(this commit also contains some earlier commits that where not all commited in the poc/observer branch)