### PR TITLE
Copied index logic from Umbraco for ContentIndex and DeliveryApi

### DIFF
--- a/src/Bielu.Examine.Core/Indexers/ElasticSearchBaseIndex.cs
+++ b/src/Bielu.Examine.Core/Indexers/ElasticSearchBaseIndex.cs
@@ -130,4 +130,9 @@ public class ElasticSearchBaseIndex(
         value.ValueSet = indexingNodeDataArgs.ValueSet;
         value.Cancel = indexingNodeDataArgs.Cancel;
     }
+
+    public long DeleteBatch(IEnumerable<string> itemIds)
+    {
+        return elasticSearchService.DeleteBatch(name, itemIds);
+    }
 }

--- a/src/Bielu.Examine.Umbraco/Bielu.Examine.Umbraco.csproj
+++ b/src/Bielu.Examine.Umbraco/Bielu.Examine.Umbraco.csproj
@@ -15,8 +15,6 @@
       </PackageReference>
       <PackageReference Include="Umbraco.Cms.Examine.Lucene">
       </PackageReference>
-      <PackageReference Include="Umbraco.Cms.Infrastructure">
-      </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Bielu.Examine.Umbraco/Indexers/UmbracoContentElasticsearchIndex.cs
+++ b/src/Bielu.Examine.Umbraco/Indexers/UmbracoContentElasticsearchIndex.cs
@@ -1,5 +1,7 @@
 using Bielu.Examine.Core.Services;
+using Examine;
 using Examine.Lucene;
+using Examine.Search;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Services;
@@ -7,7 +9,104 @@ using Umbraco.Cms.Infrastructure.Examine;
 
 namespace bielu.Examine.Umbraco.Indexers.Indexers;
 
-public class BieluExamineUmbracoContentIndex(string? name, ILoggerFactory loggerFactory, IRuntime runtime, ILogger<IBieluExamineIndex> logger, ISearchService searchService, IIndexStateService stateService, IBieluSearchManager manager, IOptionsMonitor<LuceneDirectoryIndexOptions> indexOptions) : BieluExamineUmbracoIndex(name, loggerFactory, runtime, logger, searchService, stateService, manager, indexOptions), IUmbracoContentIndex
+public class BieluExamineUmbracoContentIndex : BieluExamineUmbracoIndex, IUmbracoContentIndex
+
 {
+    private readonly ISet<string> _idOnlyFieldSet = new HashSet<string> { "id" };
+    public BieluExamineUmbracoContentIndex(string? name, ILoggerFactory loggerFactory, IRuntime runtime, ILogger<IBieluExamineIndex> logger, ISearchService searchService, IIndexStateService stateService, IBieluSearchManager manager, IOptionsMonitor<LuceneDirectoryIndexOptions> indexOptions) : base(name, loggerFactory, runtime, logger, searchService, stateService, manager, indexOptions)
+    {
+        LuceneDirectoryIndexOptions namedOptions = indexOptions.Get(name);
+        if (namedOptions == null)
+        {
+            throw new InvalidOperationException(
+                $"No named {typeof(LuceneDirectoryIndexOptions)} options with name {name}");
+        }
+
+        if (namedOptions.Validator is IContentValueSetValidator contentValueSetValidator)
+        {
+            PublishedValuesOnly = contentValueSetValidator.PublishedValuesOnly;
+            SupportProtectedContent = contentValueSetValidator.SupportProtectedContent;
+        }
+    }
+
+    protected override void PerformIndexItems(IEnumerable<ValueSet> values, Action<IndexOperationEventArgs> onComplete)
+    {
+        // We don't want to re-enumerate this list, but we need to split it into 2x enumerables: invalid and valid items.
+        // The Invalid items will be deleted, these are items that have invalid paths (i.e. moved to the recycle bin, etc...)
+        // Then we'll index the Value group all together.
+        var invalidOrValid = values.GroupBy(v =>
+        {
+            if (!v.Values.TryGetValue("path", out IReadOnlyList<object>? paths) || paths.Count <= 0 || paths[0] == null)
+            {
+                return ValueSetValidationStatus.Failed;
+            }
+
+            ValueSetValidationResult validationResult = ValueSetValidator.Validate(v);
+
+            return validationResult.Status;
+        }).ToArray();
+
+        var hasDeletes = false;
+        var hasUpdates = false;
+
+        // ordering by descending so that Filtered/Failed processes first
+        foreach (IGrouping<ValueSetValidationStatus, ValueSet> group in invalidOrValid.OrderByDescending(x => x.Key))
+        {
+            switch (group.Key)
+            {
+                case ValueSetValidationStatus.Valid:
+                    hasUpdates = true;
+
+                    //these are the valid ones, so just index them all at once
+                    base.PerformIndexItems(group.ToArray(), onComplete);
+                    break;
+                case ValueSetValidationStatus.Failed:
+                    // don't index anything that is invalid
+                    break;
+                case ValueSetValidationStatus.Filtered:
+                    hasDeletes = true;
+
+                    // these are the invalid/filtered items so we'll delete them
+                    // since the path is not valid we need to delete this item in
+                    // case it exists in the index already and has now
+                    // been moved to an invalid parent.
+                    base.PerformDeleteFromIndex(group.Select(x => x.Id), null);
+                    break;
+            }
+        }
+
+        if ((hasDeletes && !hasUpdates) || (!hasDeletes && !hasUpdates))
+        {
+            //we need to manually call the completed method
+            onComplete(new IndexOperationEventArgs(this, 0));
+        }
+    }
+
+    protected override void PerformDeleteFromIndex(IEnumerable<string> itemIds, Action<IndexOperationEventArgs> onComplete)
+    {
+        var idsAsList = itemIds.Where(x => !string.IsNullOrWhiteSpace(x)).ToList();
+        var childIdsToDelete = new List<string>();
+
+        for (var i = 0; i < idsAsList.Count; i++)
+        {
+            var nodeId = idsAsList[i];
+
+            //find all descendants based on path
+            var descendantPath = $@"\-1*\,{nodeId}\,*";
+            var rawQuery = $"{UmbracoExamineFieldNames.IndexPathFieldName}:{descendantPath}";
+            IQuery? c = Searcher.CreateQuery();
+            IBooleanOperation? filtered = c.NativeQuery(rawQuery);
+            IOrdering? selectedFields = filtered.SelectFields(_idOnlyFieldSet);
+            ISearchResults? results = selectedFields.Execute();
+
+            childIdsToDelete.AddRange(results.Select(x => x.Id));
+            idsAsList.RemoveAll(x => childIdsToDelete.Contains(x));
+        }
+
+        idsAsList.AddRange(childIdsToDelete);
+
+        var response = base.DeleteBatch(idsAsList.Distinct());
+    }
 
 }
+

--- a/src/Bielu.Examine.Umbraco/Indexers/UmbracoDeliveryApiContentElasticSearchIndex.cs
+++ b/src/Bielu.Examine.Umbraco/Indexers/UmbracoDeliveryApiContentElasticSearchIndex.cs
@@ -1,12 +1,104 @@
+using System.Globalization;
 using Bielu.Examine.Core.Services;
+using Examine;
 using Examine.Lucene;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.DeliveryApi;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.Examine;
+using Umbraco.Extensions;
 
 namespace bielu.Examine.Umbraco.Indexers.Indexers;
 
-public class BieluExamineUmbracoDeliveryApiContentIndex(string? name, ILoggerFactory loggerFactory, IRuntime runtime, ILogger<IBieluExamineIndex> logger, ISearchService searchService, IIndexStateService stateService, IBieluSearchManager manager, IOptionsMonitor<LuceneDirectoryIndexOptions> indexOptions) : BieluExamineUmbracoIndex(name, loggerFactory, runtime, logger, searchService, stateService, manager, indexOptions)
+public class BieluExamineUmbracoDeliveryApiContentIndex : BieluExamineUmbracoIndex
 {
+    private readonly IDeliveryApiCompositeIdHandler _deliveryApiCompositeIdHandler;
+    private readonly ILogger _logger;
+    public BieluExamineUmbracoDeliveryApiContentIndex(string? name, ILoggerFactory loggerFactory, IRuntime runtime, ILogger<IBieluExamineIndex> logger, ISearchService searchService, IIndexStateService stateService, IBieluSearchManager manager, IOptionsMonitor<LuceneDirectoryIndexOptions> indexOptions, IDeliveryApiCompositeIdHandler deliveryApiCompositeIdHandler) : base(name, loggerFactory, runtime, logger, searchService, stateService, manager, indexOptions)
+    {
+        _logger = logger;
+        _deliveryApiCompositeIdHandler = deliveryApiCompositeIdHandler;
+        PublishedValuesOnly = false;
+        EnableDefaultEventHandler = false;
+    }
 
+    protected override void PerformDeleteFromIndex(IEnumerable<string> itemIds, Action<IndexOperationEventArgs>? onComplete)
+    {
+        var removedIndexIds = new List<string>();
+        var removedContentIds = new List<string>();
+        foreach (var itemId in itemIds)
+        {
+            // if this item was already removed as a descendant of a previously removed item, skip it
+            if (removedIndexIds.Contains(itemId))
+            {
+                continue;
+            }
+
+            // an item ID passed to this method can be a composite of content ID and culture (like "1234|da-DK") or simply a content ID
+            // - when it's a composite ID, only the supplied culture of the given item should be deleted from the index
+            // - when it's an content ID, all cultures of the of the given item should be deleted from the index
+            var (contentId, culture) = ParseItemId(itemId);
+            if (contentId is null)
+            {
+                _logger.LogWarning("Could not parse item ID; expected integer or composite ID, got: {itemId}", itemId);
+                continue;
+            }
+
+            // if this item was already removed as a descendant of a previously removed item (for all cultures), skip it
+            if (culture is null && removedContentIds.Contains(contentId))
+            {
+                continue;
+            }
+
+            // find descendants-or-self based on path and optional culture
+            var rawQuery = $"({UmbracoExamineFieldNames.DeliveryApiContentIndex.Id}:{contentId} OR {UmbracoExamineFieldNames.IndexPathFieldName}:\\-1*,{contentId},*)";
+            if (culture is not null)
+            {
+                rawQuery = $"{rawQuery} AND culture:{culture}";
+            }
+
+            ISearchResults results = Searcher
+                .CreateQuery()
+                .NativeQuery(rawQuery)
+                // NOTE: we need to be explicit about fetching ItemIdFieldName here, otherwise Examine will try to be
+                // clever and use the "id" field of the document (which we can't use for deletion)
+                .SelectField(UmbracoExamineFieldNames.ItemIdFieldName)
+                .Execute();
+
+            _logger.LogDebug("DeleteFromIndex with query: {Query} (found {TotalItems} results)", rawQuery, results.TotalItemCount);
+
+            // grab the index IDs from the index (the composite IDs)
+            var indexIds = results.Select(x => x.Id).ToList();
+
+            // remember which items we removed, so we can skip those later
+            removedIndexIds.AddRange(indexIds);
+            if (culture is null)
+            {
+                removedContentIds.AddRange(indexIds.Select(indexId => ParseItemId(indexId).ContentId).WhereNotNull());
+            }
+
+            // delete the resulting items from the index
+            base.PerformDeleteFromIndex(indexIds, null);
+        }
+    }
+
+    private (string? ContentId, string? Culture) ParseItemId(string id)
+    {
+        if (int.TryParse(id, out _))
+        {
+            return (id, null);
+        }
+
+        DeliveryApiIndexCompositeIdModel compositeIdModel = _deliveryApiCompositeIdHandler.Decompose(id);
+
+        return (compositeIdModel.Id?.ToString(CultureInfo.InvariantCulture), compositeIdModel.Culture);
+    }
+
+
+    protected override void OnTransformingIndexValues(IndexingItemEventArgs e)
+    {
+        // UmbracoExamineIndex (base class down the hierarchy) performs some magic transformations here for paths and icons;
+        // we don't want that for the Delivery API, so we'll have to override this method and simply do nothing.
+    }
 }


### PR DESCRIPTION
Filtering unpublished and protected content turned out not to work sufficiently, so that unpublished and protected content still ended up in the ExternalIndex when reindexing. I adopted the logic for this from Umbraco Lucene indexes.