### PR TITLE
ContentDeliveryApi query and filter fixes

### DIFF
--- a/src/Bielu.Examine.Core/Services/IBieluExamineSearcher.cs
+++ b/src/Bielu.Examine.Core/Services/IBieluExamineSearcher.cs
@@ -1,5 +1,8 @@
-﻿using Bielu.Examine.Core.Models;
+using Bielu.Examine.Core.Models;
 using Examine;
+using Examine.Lucene.Search;
+using Examine.Search;
+using Lucene.Net.Analysis;
 
 namespace Bielu.Examine.Core.Services;
 
@@ -7,4 +10,6 @@ public interface IBieluExamineSearcher : ISearcher
 {
     string[] AllFields { get; }
     IEnumerable<ExamineProperty> AllProperties { get;}
+
+    IQuery CreateQuery(string category, BooleanOperation defaultOperation, Analyzer? luceneAnalyzer, LuceneSearchOptions? searchOptions);
 }

--- a/src/Bielu.Examine.Core/Services/IElasticSearchService.cs
+++ b/src/Bielu.Examine.Core/Services/IElasticSearchService.cs
@@ -1,6 +1,8 @@
-﻿using Bielu.Examine.Core.Models;
+using Bielu.Examine.Core.Models;
 using Examine;
+using Examine.Lucene.Search;
 using Examine.Search;
+using Lucene.Net.Analysis;
 using Lucene.Net.Search;
 
 namespace Bielu.Examine.Core.Services;
@@ -19,5 +21,5 @@ public interface ISearchService : IObservable<TransformingObservable>
     long DeleteBatch(string? examineIndexName, IEnumerable<string> itemIds);
     int GetDocumentCount(string? examineIndexName);
     bool HealthCheck(string? examineIndexNam);
-    IQuery CreateQuery(string name, string? indexAlias, string category, BooleanOperation defaultOperation);
+    IQuery CreateQuery(string name, string? indexAlias, string category, BooleanOperation defaultOperation, Analyzer? luceneAnalyzer, LuceneSearchOptions? searchOptions);
 }

--- a/src/Bielu.Examine.ElasticSearch/Providers/ElasticsearchExamineSearcher.cs
+++ b/src/Bielu.Examine.ElasticSearch/Providers/ElasticsearchExamineSearcher.cs
@@ -1,23 +1,14 @@
 using Bielu.Examine.Core.Models;
-using Bielu.Examine.Core.Queries;
 using Bielu.Examine.Core.Services;
-using Bielu.Examine.Elasticsearch.Configuration;
-using Bielu.Examine.Elasticsearch.Extensions;
 using Bielu.Examine.Elasticsearch.Model;
-using Bielu.Examine.Elasticsearch.Services;
 using Elastic.Clients.Elasticsearch;
-using Elastic.Clients.Elasticsearch.IndexManagement;
-using Elastic.Clients.Elasticsearch.Mapping;
 using Elastic.Clients.Elasticsearch.QueryDsl;
-using Elastic.Transport.Extensions;
 using Examine;
 using Examine.Lucene.Search;
 using Examine.Search;
-using Lucene.Net.Analysis.Standard;
+using Lucene.Net.Analysis;
 using Lucene.Net.Search;
-using Lucene.Net.Util;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Query = Elastic.Clients.Elasticsearch.QueryDsl.Query;
 
 namespace Bielu.Examine.Elasticsearch.Providers;
@@ -98,9 +89,15 @@ public class ElasticsearchExamineSearcher(string name, string? indexAlias, ILogg
             return _parsedValues;
         }
     }
+
+
     public override IQuery CreateQuery(string category = null,
-        BooleanOperation defaultOperation = BooleanOperation.And) => elasticsearchService.CreateQuery(name, indexAlias, category, defaultOperation);
- #pragma warning disable CA1816
+        BooleanOperation defaultOperation = BooleanOperation.And) => elasticsearchService.CreateQuery(name, indexAlias, category, defaultOperation, null, null);
+
+    public IQuery CreateQuery(string category, BooleanOperation defaultOperation, Analyzer? luceneAnalyzer, LuceneSearchOptions? searchOptions) => elasticsearchService.CreateQuery(name, indexAlias, category, defaultOperation, luceneAnalyzer, searchOptions);
+
+
+#pragma warning disable CA1816
     public void Dispose() => loggerFactory.Dispose();
  #pragma warning restore CA1816
 }

--- a/src/Bielu.Examine.ElasticSearch/Services/ElasticsearchService.cs
+++ b/src/Bielu.Examine.ElasticSearch/Services/ElasticsearchService.cs
@@ -12,6 +12,7 @@ using Elastic.Clients.Elasticsearch.QueryDsl;
 using Examine;
 using Examine.Lucene.Search;
 using Examine.Search;
+using Lucene.Net.Analysis;
 using Lucene.Net.Analysis.Standard;
 using Lucene.Net.Documents;
 using Lucene.Net.Util;
@@ -315,11 +316,12 @@ public class ElasticsearchService(
                client.Cluster.Health().Status == HealthStatus.Yellow;
     }
 
-    public IQuery CreateQuery(string name, string? indexAlias, string category, BooleanOperation defaultOperation) =>
+    public IQuery CreateQuery(string name, string? indexAlias, string category, BooleanOperation defaultOperation, Analyzer? luceneAnalyzer, LuceneSearchOptions? searchOptions) =>
         new BieluExamineQuery(name, indexAlias,
             new ElasticSearchQueryParser(LuceneVersion.LUCENE_CURRENT, GetPropertiesNames(name).ToArray(),
-                new StandardAnalyzer(LuceneVersion.LUCENE_48)), this, loggerFactory,
-            loggerFactory.CreateLogger<BieluExamineQuery>(), category, new LuceneSearchOptions(), defaultOperation);
+              luceneAnalyzer ?? new StandardAnalyzer(LuceneVersion.LUCENE_48)), this, loggerFactory,
+            loggerFactory.CreateLogger<BieluExamineQuery>(), category, searchOptions ?? new LuceneSearchOptions(), defaultOperation);
+
 
     private static string CreateIndexName(string indexAlias)
     {

--- a/src/Bielu.Examine.ElasticSearch/Services/PropertyMappingService.cs
+++ b/src/Bielu.Examine.ElasticSearch/Services/PropertyMappingService.cs
@@ -3,7 +3,6 @@ using Bielu.Examine.Core.Extensions;
 using Bielu.Examine.Elasticsearch.Model;
 using Elastic.Clients.Elasticsearch.Mapping;
 using Examine;
-using Lucene.Net.Analysis;
 
 namespace Bielu.Examine.Elasticsearch.Services;
 
@@ -28,10 +27,11 @@ public class PropertyMappingService(BieluExamineConfiguration configuration) : I
             "float" => descriptor.FloatNumber(fieldName),
             "long" => descriptor.LongNumber(fieldName),
             var type when _integerFormats.Contains(type) => descriptor.IntegerNumber(fieldName),
-            "raw" => descriptor.Keyword(fieldName),
+            "raw" => descriptor.Text(fieldName, configure => configure.Analyzer("keyword")),
             "keyword" => descriptor.Keyword(fieldName),
             _ => descriptor.Text(fieldName, configure => configure.Analyzer(FromLuceneAnalyzer(analyzer)))
         };
+
     }
     private static string FromLuceneAnalyzer(string? analyzer)
     {

--- a/src/Bielu.Examine.Umbraco/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Bielu.Examine.Umbraco/Extensions/ServiceCollectionExtensions.cs
@@ -11,6 +11,8 @@ using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Infrastructure.Examine;
 using Umbraco.Extensions;
+using bielu.Examine.Umbraco.Services.QueryBuilders;
+using Umbraco.Cms.Api.Delivery.Services.QueryBuilders;
 
 namespace bielu.Examine.Umbraco.Extensions;
 
@@ -19,12 +21,14 @@ public static class UmbracoBuilderExtensions
     public static IUmbracoBuilder AddBieluExamineForUmbraco(this IUmbracoBuilder builder, Action<BieluExamineConfigurator?> configure)
     {
         builder.Services.AddCoreServices(configure);
+
         var config= BieluExamineConfiguration.Instance;
         if (config.FieldAnalyzerFieldMapping.TryGetValue("keyword", out var keyword))
         {
             keyword.Add(BieluExamineUmbracoIndex.IndexPathFieldName);
         }
         builder.Services.AddUnique<IIndexRebuilder, ElasticsearchExamineIndexRebuilder>();
+        builder.Services.AddSingleton<IApiContentQueryFactory, ApiContentQueryFactory>();
 
         builder.Services.AddSingleton<IIndexDiagnosticsFactory, LuceneIndexDiagnosticsFactory>();
         builder.Services.AddBieluExamineIndex<BieluExamineUmbracoContentIndex>(global::Umbraco.Cms.Core.Constants.UmbracoIndexes

--- a/src/Bielu.Examine.Umbraco/Services/QueryBuilders/ApiContentQueryFactory.cs
+++ b/src/Bielu.Examine.Umbraco/Services/QueryBuilders/ApiContentQueryFactory.cs
@@ -1,0 +1,28 @@
+using Bielu.Examine.Core.Services;
+using Examine;
+using Examine.Lucene.Search;
+using Examine.Search;
+using Lucene.Net.Analysis.Core;
+using Umbraco.Cms.Api.Delivery.Services.QueryBuilders;
+using Umbraco.Cms.Infrastructure.Examine;
+
+namespace bielu.Examine.Umbraco.Services.QueryBuilders
+{
+    internal sealed class ApiContentQueryFactory : IApiContentQueryFactory
+    {
+        /// <inheritdoc/>
+        public IQuery CreateApiContentQuery(IIndex index)
+        {
+            // Needed for enabling leading wildcards searches
+            IBieluExamineSearcher searcher = index.Searcher as IBieluExamineSearcher ?? throw new InvalidOperationException($"Index searcher must be of type {nameof(IBieluExamineSearcher)}.");
+
+            IQuery query = searcher.CreateQuery(
+                IndexTypes.Content,
+                BooleanOperation.And,
+                new KeywordAnalyzer(),
+                new LuceneSearchOptions() { AllowLeadingWildcard = true });
+
+            return query;
+        }
+    }
+}

--- a/src/Bielu.Examine.Umbraco/Services/UmbracoElasticSearchServiceDecorator.cs
+++ b/src/Bielu.Examine.Umbraco/Services/UmbracoElasticSearchServiceDecorator.cs
@@ -1,7 +1,9 @@
-﻿using Bielu.Examine.Core.Models;
+using Bielu.Examine.Core.Models;
 using Bielu.Examine.Core.Services;
 using Examine;
+using Examine.Lucene.Search;
 using Examine.Search;
+using Lucene.Net.Analysis;
 using Lucene.Net.Documents;
 using Lucene.Net.Search;
 using Umbraco.Cms.Core.Sync;
@@ -49,6 +51,6 @@ public class UmbracoElasticSearchServiceDecorator(ISearchService searchService, 
     }
     public int GetDocumentCount(string? examineIndexName) => searchService.GetDocumentCount(examineIndexName);
     public bool HealthCheck(string? examineIndexNam) => searchService.HealthCheck(examineIndexNam);
-    public IQuery CreateQuery(string name, string? indexAlias, string category, BooleanOperation defaultOperation) => searchService.CreateQuery(name, indexAlias, category, defaultOperation);
+    public IQuery CreateQuery(string name, string? indexAlias, string category, BooleanOperation defaultOperation, Analyzer? luceneAnalyzer, LuceneSearchOptions? searchOptions) => searchService.CreateQuery(name, indexAlias, category, defaultOperation, luceneAnalyzer, searchOptions);
     public IDisposable Subscribe(IObserver<TransformingObservable> observer) => searchService.Subscribe(observer);
 }


### PR DESCRIPTION
This commit makes the query and filter functions of the ContentDeliveryApi work with ElasticSearch by registering a custom ApiContentQueryFactory and modifying the CreateQuery interface to so that a (keyword)analyzer can be set.

A few interfaces have been modified as a result.